### PR TITLE
Add experiment-as-flag for Fx 38.1/iOS launch.

### DIFF
--- a/defaults.json
+++ b/defaults.json
@@ -1,3 +1,8 @@
 {
-  "avatarLinkVisible": false
+  "avatarLinkVisible": false,
+  "fxIos": {
+    "launched": false,
+    "appStoreLinkDirect": "",
+    "appStoreLinkWeb": ""
+  }
 }

--- a/fxios-launched/fxios-launched.js
+++ b/fxios-launched/fxios-launched.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  name: 'Has Firefox for iOS launched',
+  endDate: '2015-06-02',
+  independentVariables: ['fxIos'],
+  eligibilityFunction: function() {},
+  groupingFunction: function() {},
+  conclusion: {
+    fxIos: {
+      launched: true,
+      appStoreLinkDirect: 'itms://itunes.apple.com/us/app/sync-for-firefox/id468995230',
+      appStoreLinkWeb: 'https://itunes.apple.com/us/app/sync-for-firefox/id468995230'
+      // links above are not final
+    }
+  }
+};


### PR DESCRIPTION
_Do not merge_

Preparing for Fx 38.1 launch. Will likely need to at least add time to `startDate` of new flag/experiment. 

Would love code review though to make sure this is the right approach.
