### PR TITLE
feat: Add communications preferences feature toggle.

### DIFF
--- a/communication-prefs/communication-prefs.js
+++ b/communication-prefs/communication-prefs.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  name: 'Are the communication preferences enabled',
+  startDate: '2015-01-01',
+  subjectAttributes: ['lang'],
+  independentVariables: ['communicationPrefsVisible'],
+  eligibilityFunction: function () {
+    return true;
+  },
+  groupingFunction: function (subject) {
+    return {
+      communicationPrefsVisible: /^en(:?-US)?/.test(subject.lang)
+    };
+  }
+};

--- a/defaults.json
+++ b/defaults.json
@@ -1,4 +1,5 @@
 {
   "avatarLinkVisible": false,
+  "communicationPrefsVisible": false,
   "springCampaign2015": false
 }


### PR DESCRIPTION
Limit the communications preferences to `en` users.

Also gives us an easy way to disable communications preferences if needed.

ref:
- https://github.com/mozilla/fxa-content-server/pull/2452
- https://github.com/mozilla/fxa-content-server/pull/2460
- https://github.com/mozilla/fxa-content-server/pull/2467
