### PR TITLE
change comm pref experiment to 10% enabled

### DIFF
--- a/communication-prefs/communication-prefs.js
+++ b/communication-prefs/communication-prefs.js
@@ -5,12 +5,13 @@ module.exports = {
   startDate: '2015-01-01',
   subjectAttributes: ['lang'],
   independentVariables: ['communicationPrefsVisible'],
-  eligibilityFunction: function () {
-    return true;
+  eligibilityFunction: function (subject) {
+    return /^en(:?-US)?/.test(subject.lang);
   },
   groupingFunction: function (subject) {
+    subject.random = subject.random || Math.random()
     return {
-      communicationPrefsVisible: /^en(:?-US)?/.test(subject.lang)
+      communicationPrefsVisible: this.bernoulliTrial(0.1, subject.random)
     };
   }
 };


### PR DESCRIPTION
The `subject.random` part is a bit of a hack. It really ought to be built into Able (I'll be updating it). The reason its not just `Math.random()` is so that multiple calls to `choose` will get the same value for a given page load.

Also, the language test should be under eligibility since other langs shouldn't get counted. It doesn't really matter in this case since there's nothing being measured, but good practice.
