### PR TITLE
fix(mailcheck): Remove the `endDate`. We aren't done with the experiment.

### DIFF
--- a/verification/mailcheck.js
+++ b/verification/mailcheck.js
@@ -4,7 +4,6 @@ module.exports = {
   name: 'mailcheck is enable or disabled',
   hypothesis: 'mailcheck will lead to higher confirmation rate of accounts',
   startDate: '2015-01-01',
-  endDate: '2015-11-01',
   subjectAttributes: ['uniqueUserId', 'isMetricsEnabledValue', 'forceExperimentGroup'],
   independentVariables: ['mailcheck'],
   eligibilityFunction: function (subject) {


### PR DESCRIPTION
@philbooth - mind an r?

Steps to test:
1. apply the patch from below to the content server.
2. restart the content server
3. from the content server's root, run `npm run test-functional grep="verification_experiments - mailcheck - treatment works"`

``` diff
diff --git a/server/lib/configuration.js b/server/lib/configuration.js
index 444ea05..49d2f8a 100644
--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -94,7 +94,7 @@ var conf = module.exports = convict({
       doc: 'path to where experiments are stored'
     },
     git: {
-      default: 'github:mozilla/fxa-content-experiments#dev',
+      default: 'github:mozilla/fxa-content-experiments#mailcheck-expiration',
       doc: 'git url for experiments repo. set to empty to not pull'
     },
     watch: {
```
