### PR TITLE
feat(CAD): Enable CAD for 100% of users.

### DIFF
--- a/connect-another-device/connect-another-device.js
+++ b/connect-another-device/connect-another-device.js
@@ -4,35 +4,15 @@ module.exports = {
   name: 'Should the user see the "connect another device" screen',
   hypothesis: 'A nudge to connect another device will help increase multi-device users',
   startDate: '2015-01-01',
-  subjectAttributes: ['uniqueUserId', 'forceExperiment', 'forceExperimentGroup'],
+  subjectAttributes: [],
   independentVariables: ['connectAnotherDevice'],
   eligibilityFunction: function (subject) {
-    if (! subject) {
-      return false;
-    }
-
-    if (subject.forceExperiment === 'connectAnotherDevice') {
-      return true;
-    }
-
-    // Place 50% of users into the two buckets, meaning the feature
-    // will be enabled for ~25% of users. 'isMetricsEnabledValue' is
-    // ignored, we have sufficiently high numbers that we'll assume
-    // an equal number of users who have metrics enabled are in each
-    // bucket. This assumption is measured in DataDog.
-    return this.bernoulliTrial(0.5, subject.uniqueUserId);
+    return true;
   },
 
   groupingFunction: function (subject) {
-    var GROUPS = ['control', 'treatment'];
-    var choice = this.uniformChoice(GROUPS, subject.uniqueUserId);
-
-    if (subject.forceExperimentGroup) {
-      choice = subject.forceExperimentGroup;
-    }
-
     return {
-      connectAnotherDevice: choice
+      connectAnotherDevice: 'treatment'
     };
   }
 };


### PR DESCRIPTION
### What is the problem?
The new CAD screens are only presented to 25% of users. The app store links and ability to sign in have proven successful.

### How does this fix it?
This pushes 100% of users through the new CAD screens.

### Why didn't you just remove the experiment?
I want to keep DataDog metrics collection going while we roll this out. Once 100% of users see the experiment and it's still proves useful/relatively bug free, I'll remove the experiment. Maybe I'm thinking about it wrong though.

@vladikoff - r?